### PR TITLE
Added space after get_count function definition

### DIFF
--- a/src/Sergigp/Funiculus/funiculus.php
+++ b/src/Sergigp/Funiculus/funiculus.php
@@ -74,7 +74,7 @@ namespace Sergigp\Funiculus
         return $r;
     }
 
-    function get_count($sq)
+    function get_count ($sq)
     {
         return is_array($sq) ? count($sq) : iterator_count($sq);
     }


### PR DESCRIPTION
According with the general library coding style.
